### PR TITLE
Update for Faraday 2

### DIFF
--- a/faraday-em_synchrony.gemspec
+++ b/faraday-em_synchrony.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.homepage = 'https://github.com/lostisland/faraday-em_synchrony'
   spec.license = 'MIT'
 
-  spec.required_ruby_version = Gem::Requirement.new('>= 2.4.0')
+  spec.required_ruby_version = Gem::Requirement.new('>= 2.6.0')
 
   spec.metadata['homepage_uri'] = spec.homepage
   spec.metadata['source_code_uri'] = 'https://github.com/lostisland/faraday-em_synchrony'
@@ -22,11 +22,10 @@ Gem::Specification.new do |spec|
   spec.files = Dir.glob('lib/**/*') + %w[README.md LICENSE.md]
   spec.require_paths = ['lib']
 
-  # TODO: make these normal dependencies when releasing v2.0 together with Faraday v2.0
-  spec.add_development_dependency 'em-http-request', '>= 1.1'
-  spec.add_development_dependency 'em-synchrony', '>= 1.0.3'
-  spec.add_development_dependency 'faraday', '~> 1.0'
-  spec.add_development_dependency 'faraday-em_http', '~> 1.0'
+  spec.add_runtime_dependency 'em-http-request', '>= 1.1'
+  spec.add_runtime_dependency 'em-synchrony', '>= 1.0.3'
+  spec.add_runtime_dependency 'faraday', '~> 2.0'
+  spec.add_runtime_dependency 'faraday-em_http', '~> 2.0'
 
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'rake', '~> 13.0'

--- a/lib/faraday/adapter/em_synchrony.rb
+++ b/lib/faraday/adapter/em_synchrony.rb
@@ -1,34 +1,29 @@
 # frozen_string_literal: true
 
 require 'uri'
+require 'em-synchrony/em-http'
+require 'em-synchrony/em-multi'
+require 'fiber'
+
+require 'faraday/adapter/em_synchrony/parallel_manager'
+
+begin
+  require 'openssl'
+rescue LoadError
+  warn 'Warning: no such file to load -- openssl. ' \
+    'Make sure it is installed if you want HTTPS support'
+else
+  require 'em-http/version'
+  if EventMachine::HttpRequest::VERSION < '1.1.6'
+    require 'faraday/adapter/em_http_ssl_patch'
+  end
+end
 
 module Faraday
   class Adapter
     # EventMachine Synchrony adapter.
     class EMSynchrony < Faraday::Adapter
       include EMHttp::Options
-
-      dependency do
-        require 'em-synchrony/em-http'
-        require 'em-synchrony/em-multi'
-        require 'fiber'
-
-        require 'faraday/adapter/em_synchrony/parallel_manager'
-
-        if Faraday::Adapter::EMSynchrony.loaded?
-          begin
-            require 'openssl'
-          rescue LoadError
-            warn 'Warning: no such file to load -- openssl. ' \
-              'Make sure it is installed if you want HTTPS support'
-          else
-            require 'em-http/version'
-            if EventMachine::HttpRequest::VERSION < '1.1.6'
-              require 'faraday/adapter/em_http_ssl_patch'
-            end
-          end
-        end
-      end
 
       self.supports_parallel = true
 

--- a/lib/faraday/em_synchrony.rb
+++ b/lib/faraday/em_synchrony.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'faraday'
 require 'faraday/em_http'
 require_relative 'adapter/em_synchrony'
 require_relative 'em_synchrony/version'


### PR DESCRIPTION
Remove `dependency` block because it doesn't exist in Faraday 2 and instead require at load time. Update runtime dependencies to target faraday ~> 2.0 and faraday-em_http ~> 2.0.

Happy to make whatever further changes are needed!

Fixes: #5